### PR TITLE
Add stages + lot of other changes :)

### DIFF
--- a/src/include/libpmemblk/async.h
+++ b/src/include/libpmemblk/async.h
@@ -75,27 +75,33 @@ struct pmemblk_read_async_future pmemblk_read_async(PMEMblkpool *pbp, void *buf,
 /* END of pmemblk_read_async future */
 
 /* START of pmemblk_write_async future */
-struct pmemblk_write_async_future_data {
+enum pmemblk_write_stages{
+	PMEMBLK_WRITE_INITIALIZED = 0,
+	PMEMBLK_WRITE_WAITING_FOR_LANE = 1,
+	PMEMBLK_WRITE_IN_PROGRESS = 2,
+	PMEMBLK_WRITE_COMPLETE = 20,
+};
+struct pmemblk_write_async_data {
 	PMEMblkpool *pbp;
 	void *buf;
 	long long blockno;
 
+	int stage;
 	struct {
 		struct btt_write_async_future btt_write_fut;
-		int btt_write_started;
 		unsigned lane;
 	} internal;
 };
 
-struct pmemblk_write_async_future_output {
+struct pmemblk_write_async_output {
 	int return_value;
 };
 
-FUTURE(pmemblk_write_async_future, struct pmemblk_write_async_future_data,
-		struct pmemblk_write_async_future_output);
+FUTURE(pmemblk_write_async_fut, struct pmemblk_write_async_data,
+		struct pmemblk_write_async_output);
 
-struct pmemblk_write_async_future pmemblk_write_async(PMEMblkpool *pbp,
-		void *buf, long long blockno);
+struct pmemblk_write_async_fut pmemblk_write_async(PMEMblkpool *pbp, void *buf,
+		long long blockno);
 /* END of pmemblk_write_async future */
 #endif
 

--- a/src/include/libpmemblk/async.h
+++ b/src/include/libpmemblk/async.h
@@ -41,26 +41,26 @@ PMEMblkpool *pmemblk_xcreateW(const wchar_t *path, size_t bsize,
 #else
 PMEMblkpool *pmemblk_xopen(const char *path, size_t bsize, struct vdm *vdm);
 PMEMblkpool *pmemblk_xcreate(const char *path, size_t bsize, size_t poolsize,
-		mode_t mode, struct vdm *vdm);
+	mode_t mode, struct vdm *vdm);
 #endif
 
 /* START of pmemblk_read_async future */
-enum pmemblk_read_stages{
+enum pmemblk_read_stages {
 	PMEMBLK_READ_INITIALIZED = 0,
 	PMEMBLK_READ_WAITING_FOR_LANE = 1,
 	PMEMBLK_READ_IN_PROGRESS = 2,
 	PMEMBLK_READ_COMPLETE = 20,
 };
 struct pmemblk_read_async_data {
-    PMEMblkpool *pbp;
-    void *buf;
-    long long blockno;
+	PMEMblkpool *pbp;
+	void *buf;
+	long long blockno;
 
-    int stage;
-    struct {
-	struct btt_read_async_future btt_read_fut;
-	unsigned lane;
-    } internal;
+	int stage;
+	struct {
+		struct btt_read_async_future btt_read_fut;
+		unsigned lane;
+	} internal;
 };
 
 struct pmemblk_read_async_output {
@@ -75,7 +75,7 @@ struct pmemblk_read_async_future pmemblk_read_async(PMEMblkpool *pbp, void *buf,
 /* END of pmemblk_read_async future */
 
 /* START of pmemblk_write_async future */
-enum pmemblk_write_stages{
+enum pmemblk_write_stages {
 	PMEMBLK_WRITE_INITIALIZED = 0,
 	PMEMBLK_WRITE_WAITING_FOR_LANE = 1,
 	PMEMBLK_WRITE_IN_PROGRESS = 2,
@@ -100,8 +100,8 @@ struct pmemblk_write_async_output {
 FUTURE(pmemblk_write_async_future, struct pmemblk_write_async_data,
 		struct pmemblk_write_async_output);
 
-struct pmemblk_write_async_future pmemblk_write_async(PMEMblkpool *pbp, void *buf,
-		long long blockno);
+struct pmemblk_write_async_future pmemblk_write_async(PMEMblkpool *pbp,
+	void *buf, long long blockno);
 /* END of pmemblk_write_async future */
 #endif
 

--- a/src/include/libpmemblk/async.h
+++ b/src/include/libpmemblk/async.h
@@ -51,7 +51,7 @@ enum pmemblk_read_stages{
 	PMEMBLK_READ_IN_PROGRESS = 2,
 	PMEMBLK_READ_COMPLETE = 20,
 };
-struct pmemblk_read_async_future_data {
+struct pmemblk_read_async_data {
     PMEMblkpool *pbp;
     void *buf;
     long long blockno;
@@ -63,12 +63,12 @@ struct pmemblk_read_async_future_data {
     } internal;
 };
 
-struct pmemblk_read_async_future_output {
+struct pmemblk_read_async_output {
     int return_value;
 };
 
-FUTURE(pmemblk_read_async_future, struct pmemblk_read_async_future_data,
-	struct pmemblk_read_async_future_output);
+FUTURE(pmemblk_read_async_future, struct pmemblk_read_async_data,
+	struct pmemblk_read_async_output);
 
 struct pmemblk_read_async_future pmemblk_read_async(PMEMblkpool *pbp, void *buf,
 	long long blockno);
@@ -97,10 +97,10 @@ struct pmemblk_write_async_output {
 	int return_value;
 };
 
-FUTURE(pmemblk_write_async_fut, struct pmemblk_write_async_data,
+FUTURE(pmemblk_write_async_future, struct pmemblk_write_async_data,
 		struct pmemblk_write_async_output);
 
-struct pmemblk_write_async_fut pmemblk_write_async(PMEMblkpool *pbp, void *buf,
+struct pmemblk_write_async_future pmemblk_write_async(PMEMblkpool *pbp, void *buf,
 		long long blockno);
 /* END of pmemblk_write_async future */
 #endif

--- a/src/include/libpmemblk/btt_async.h
+++ b/src/include/libpmemblk/btt_async.h
@@ -24,19 +24,19 @@ extern "C" {
 
 /* START of nsread_async */
 struct nsread_async_data {
-    void *ns;
-    unsigned lane;
-    void *buf;
-    size_t count;
-    uint64_t off;
+	void *ns;
+	unsigned lane;
+	void *buf;
+	size_t count;
+	uint64_t off;
 
-    int memcpy_started;
-    struct vdm_operation_future op;
-    struct vdm *vdm;
+	int memcpy_started;
+	struct vdm_operation_future op;
+	struct vdm *vdm;
 };
 
 struct nsread_async_output {
-    int return_value;
+	int return_value;
 };
 
 FUTURE(nsread_async_future, struct nsread_async_data,
@@ -45,7 +45,7 @@ FUTURE(nsread_async_future, struct nsread_async_data,
 
 /* START of nswrite_async */
 struct nswrite_async_data {
-	void* ns;
+	void *ns;
 	unsigned lane;
 	void *buf;
 	size_t count;
@@ -59,7 +59,7 @@ struct nswrite_async_data {
 };
 
 struct nswrite_async_output {
-    int return_value;
+	int return_value;
 };
 
 FUTURE(nswrite_async_future, struct nswrite_async_data,
@@ -75,9 +75,8 @@ struct ns_callback_async {
 	/* TODO: finish the list!!! */
 	int (*nszero)(void *ns, unsigned lane, size_t count, uint64_t off);
 	ssize_t (*nsmap)(void *ns, unsigned lane, void **addrp,
-			size_t len, uint64_t off);
+		size_t len, uint64_t off);
 	void (*nssync)(void *ns, unsigned lane, void *addr, size_t len);
-
 	int ns_is_zeroed;
 };
 
@@ -85,35 +84,35 @@ struct ns_callback_async {
 
 /* START of btt_read_async */
 
-enum btt_read_stages{
-    BTT_READ_INITIALIZED = 10,
-    BTT_READ_ZEROS = 11,
-    BTT_READ_PREPARATION = 12,
-    BTT_READ_IN_PROGRESS = 13,
+enum btt_read_stages {
+	BTT_READ_INITIALIZED = 10,
+	BTT_READ_ZEROS = 11,
+	BTT_READ_PREPARATION = 12,
+	BTT_READ_IN_PROGRESS = 13,
 };
 struct btt_read_async_data {
-    struct btt *bttp;
-    unsigned lane;
-    uint64_t lba;
-    void *buf;
-    struct vdm *vdm;
+	struct btt *bttp;
+	unsigned lane;
+	uint64_t lba;
+	void *buf;
+	struct vdm *vdm;
 
-    int *stage;
-    struct {
-	union {
-	    struct vdm_operation_future vdm_fut;
-	    struct nsread_async_future nsread_fut;
-	};
-	struct arena *arenap;
-    } internal;
+	int *stage;
+	struct {
+		union {
+			struct vdm_operation_future vdm_fut;
+			struct nsread_async_future nsread_fut;
+		};
+		struct arena *arenap;
+	} internal;
 };
 
 struct btt_read_async_output {
-    int return_value;
+	int return_value;
 };
 
 FUTURE(btt_read_async_future, struct btt_read_async_data,
-		struct btt_read_async_output);
+	struct btt_read_async_output);
 
 struct btt_read_async_future btt_read_async(struct btt *bttp, unsigned lane,
 	uint64_t lba, void *buf, struct vdm *vdm, int *stage);
@@ -121,32 +120,32 @@ struct btt_read_async_future btt_read_async(struct btt *bttp, unsigned lane,
 
 /* START of btt_write_async */
 enum btt_write_stages {
-    BTT_WRITE_INITIALIZED = 10,
-    BTT_WRITE_WAITING_FOR_READS = 11,
-    BTT_WRITE_IN_PROGRESS = 12,
+	BTT_WRITE_INITIALIZED = 10,
+	BTT_WRITE_WAITING_FOR_READS = 11,
+	BTT_WRITE_IN_PROGRESS = 12,
 };
 struct btt_write_async_data {
-    struct btt *bttp;
-    unsigned lane;
-    uint64_t lba;
-    void *buf;
-    struct vdm *vdm;
+	struct btt *bttp;
+	unsigned lane;
+	uint64_t lba;
+	void *buf;
+	struct vdm *vdm;
 
-    int *stage;
-    struct {
-	struct nswrite_async_future nswrite_fut;
-	uint32_t premap_lba;
-	struct arena *arenap;
-	uint32_t free_entry;
-    } internal;
+	int *stage;
+	struct {
+		struct nswrite_async_future nswrite_fut;
+		uint32_t premap_lba;
+		struct arena *arenap;
+		uint32_t free_entry;
+	} internal;
 };
 
 struct btt_write_async_output {
-    int return_value;
+	int return_value;
 };
 
 FUTURE(btt_write_async_future, struct btt_write_async_data,
-		struct btt_write_async_output);
+	struct btt_write_async_output);
 
 struct btt_write_async_future btt_write_async(struct btt *bttp, unsigned lane,
 	uint64_t lba, void *buf, struct vdm *vdm, int *stage);

--- a/src/include/libpmemblk/btt_async.h
+++ b/src/include/libpmemblk/btt_async.h
@@ -23,7 +23,7 @@ extern "C" {
 /* Asynchronous callbacks */
 
 /* START of nsread_async */
-struct nsread_async_future_data {
+struct nsread_async_data {
     void *ns;
     unsigned lane;
     void *buf;
@@ -35,16 +35,16 @@ struct nsread_async_future_data {
     struct vdm *vdm;
 };
 
-struct nsread_async_future_output {
+struct nsread_async_output {
     int return_value;
 };
 
-FUTURE(nsread_async_future, struct nsread_async_future_data,
-		struct nsread_async_future_output);
+FUTURE(nsread_async_future, struct nsread_async_data,
+		struct nsread_async_output);
 /* END of nsread_async */
 
 /* START of nswrite_async */
-struct nswrite_async_future_data {
+struct nswrite_async_data {
 	void* ns;
 	unsigned lane;
 	void *buf;
@@ -58,12 +58,12 @@ struct nswrite_async_future_data {
 	} internal;
 };
 
-struct nswrite_async_future_output {
+struct nswrite_async_output {
     int return_value;
 };
 
-FUTURE(nswrite_async_future, struct nswrite_async_future_data,
-		struct nswrite_async_future_output);
+FUTURE(nswrite_async_future, struct nswrite_async_data,
+		struct nswrite_async_output);
 /* END of nswrite_async */
 
 /* TODO: Could be in a private header? */
@@ -91,7 +91,7 @@ enum btt_read_stages{
     BTT_READ_PREPARATION = 12,
     BTT_READ_IN_PROGRESS = 13,
 };
-struct btt_read_async_future_data {
+struct btt_read_async_data {
     struct btt *bttp;
     unsigned lane;
     uint64_t lba;
@@ -108,12 +108,12 @@ struct btt_read_async_future_data {
     } internal;
 };
 
-struct btt_read_async_future_output {
+struct btt_read_async_output {
     int return_value;
 };
 
-FUTURE(btt_read_async_future, struct btt_read_async_future_data,
-		struct btt_read_async_future_output);
+FUTURE(btt_read_async_future, struct btt_read_async_data,
+		struct btt_read_async_output);
 
 struct btt_read_async_future btt_read_async(struct btt *bttp, unsigned lane,
 	uint64_t lba, void *buf, struct vdm *vdm, int *stage);
@@ -125,7 +125,7 @@ enum btt_write_stages {
     BTT_WRITE_WAITING_FOR_READS = 11,
     BTT_WRITE_IN_PROGRESS = 12,
 };
-struct btt_write_async_future_data {
+struct btt_write_async_data {
     struct btt *bttp;
     unsigned lane;
     uint64_t lba;
@@ -141,12 +141,12 @@ struct btt_write_async_future_data {
     } internal;
 };
 
-struct btt_write_async_future_output {
+struct btt_write_async_output {
     int return_value;
 };
 
-FUTURE(btt_write_async_future, struct btt_write_async_future_data,
-		struct btt_write_async_future_output);
+FUTURE(btt_write_async_future, struct btt_write_async_data,
+		struct btt_write_async_output);
 
 struct btt_write_async_future btt_write_async(struct btt *bttp, unsigned lane,
 	uint64_t lba, void *buf, struct vdm *vdm, int *stage);

--- a/src/include/libpmemblk/btt_async.h
+++ b/src/include/libpmemblk/btt_async.h
@@ -90,7 +90,6 @@ enum btt_read_stages{
     BTT_READ_ZEROS = 11,
     BTT_READ_PREPARATION = 12,
     BTT_READ_IN_PROGRESS = 13,
-    BTT_READ_COMPLETE = 14,
 };
 struct btt_read_async_future_data {
     struct btt *bttp;
@@ -121,6 +120,11 @@ struct btt_read_async_future btt_read_async(struct btt *bttp, unsigned lane,
 /* END of btt_read_async */
 
 /* START of btt_write_async */
+enum btt_write_stages {
+    BTT_WRITE_INITIALIZED = 10,
+    BTT_WRITE_WAITING_FOR_READS = 11,
+    BTT_WRITE_IN_PROGRESS = 12,
+};
 struct btt_write_async_future_data {
     struct btt *bttp;
     unsigned lane;
@@ -128,9 +132,9 @@ struct btt_write_async_future_data {
     void *buf;
     struct vdm *vdm;
 
+    int *stage;
     struct {
 	struct nswrite_async_future nswrite_fut;
-	int nswrite_started;
 	uint32_t premap_lba;
 	struct arena *arenap;
 	uint32_t free_entry;
@@ -145,7 +149,7 @@ FUTURE(btt_write_async_future, struct btt_write_async_future_data,
 		struct btt_write_async_future_output);
 
 struct btt_write_async_future btt_write_async(struct btt *bttp, unsigned lane,
-	uint64_t lba, void *buf, struct vdm *vdm);
+	uint64_t lba, void *buf, struct vdm *vdm, int *stage);
 /* END of btt_write_async */
 #else
 /* dummy ns async callback structure */

--- a/src/libpmemblk/blk.c
+++ b/src/libpmemblk/blk.c
@@ -456,7 +456,7 @@ pmemblk_read_async_impl(struct future_context *ctx,
 	 */
 	if (future_poll(
 		FUTURE_AS_RUNNABLE(&data->internal.btt_read_fut), NULL)
-		!= FUTURE_STATE_COMPLETE) {
+			!= FUTURE_STATE_COMPLETE) {
 		return FUTURE_STATE_RUNNING;
 	}
 
@@ -474,7 +474,9 @@ pmemblk_read_async(PMEMblkpool *pbp, void *buf, long long blockno)
 		.data.buf = buf,
 		.data.blockno = blockno,
 		.data.internal.lane = -1,
-		.output.return_value = PMEMBLK_READ_INITIALIZED,
+		.data.stage = PMEMBLK_READ_INITIALIZED,
+
+		.output.return_value = 0,
 	};
 
 	FUTURE_INIT(&future, pmemblk_read_async_impl);
@@ -522,8 +524,8 @@ pmemblk_write_async_impl(struct future_context *ctx,
 			*stage = PMEMBLK_READ_WAITING_FOR_LANE;
 			return FUTURE_STATE_RUNNING;
 		}
-		data->internal.btt_write_fut = btt_write_async(pbp->bttp, lane,
-			blockno, buf, pbp->vdm);
+		data->internal.btt_write_fut = btt_write_async(pbp->bttp,
+			data->internal.lane,blockno, buf, pbp->vdm);
 		*stage = PMEMBLK_WRITE_IN_PROGRESS;
 	}
 

--- a/src/libpmemblk/blk.c
+++ b/src/libpmemblk/blk.c
@@ -71,7 +71,7 @@ lane_try_enter(PMEMblkpool *pbp, unsigned *lane)
 	mylane = util_fetch_and_add32(&pbp->next_lane, 1) % pbp->nlane;
 
 	/* lane selected, grab the per-lane lock */
-	if(util_mutex_trylock(&pbp->locks[mylane]) == 0) {
+	if (util_mutex_trylock(&pbp->locks[mylane]) == 0) {
 		*lane = mylane;
 		return 0;
 	} else {
@@ -286,10 +286,12 @@ static enum future_state
 nsread_async_future_impl(struct future_context *ctx,
 	struct future_notifier *notifier)
 {
-	struct nsread_async_future_data *data = future_context_get_data(ctx);
-	struct nsread_async_future_output *output = future_context_get_output(ctx);
+	struct nsread_async_future_data *data =
+		future_context_get_data(ctx);
+	struct nsread_async_future_output *output =
+		future_context_get_output(ctx);
 
-	if(!data->memcpy_started) {
+	if (!data->memcpy_started) {
 		struct pmemblk *pbp = (struct pmemblk *)data->ns;
 
 		LOG(13, "pbp %p lane %u count %zu off %" PRIu64, pbp,
@@ -309,7 +311,7 @@ nsread_async_future_impl(struct future_context *ctx,
 		data->memcpy_started = 1;
 	}
 
-	if(future_poll(FUTURE_AS_RUNNABLE(&data->op), NULL)
+	if (future_poll(FUTURE_AS_RUNNABLE(&data->op), NULL)
 		== FUTURE_STATE_COMPLETE) {
 		output->return_value = 0;
 		return FUTURE_STATE_COMPLETE;
@@ -528,7 +530,7 @@ pmemblk_write_async_impl(struct future_context *ctx,
 			return FUTURE_STATE_RUNNING;
 		}
 		data->internal.btt_write_fut = btt_write_async(pbp->bttp,
-			data->internal.lane,blockno, buf, pbp->vdm);
+			data->internal.lane, blockno, buf, pbp->vdm, stage);
 		*stage = PMEMBLK_WRITE_IN_PROGRESS;
 	}
 

--- a/src/libpmemblk/blk.c
+++ b/src/libpmemblk/blk.c
@@ -283,12 +283,12 @@ static struct ns_callback ns_cb = {
  * in an asynchronous way using libminiasync vdm
  */
 static enum future_state
-nsread_async_future_impl(struct future_context *ctx,
+nsread_async_impl(struct future_context *ctx,
 	struct future_notifier *notifier)
 {
-	struct nsread_async_future_data *data =
+	struct nsread_async_data *data =
 		future_context_get_data(ctx);
-	struct nsread_async_future_output *output =
+	struct nsread_async_output *output =
 		future_context_get_output(ctx);
 
 	if (!data->memcpy_started) {
@@ -334,7 +334,7 @@ nsread_async(void *ns, unsigned lane, void *buf,
 		.output.return_value = -1,
 	};
 
-	FUTURE_INIT(&future, nsread_async_future_impl);
+	FUTURE_INIT(&future, nsread_async_impl);
 	return future;
 }
 /*
@@ -345,11 +345,11 @@ nsread_async(void *ns, unsigned lane, void *buf,
  * START of nswrite_async_future
  */
 static enum future_state
-nswrite_async_future_impl(struct future_context *ctx,
+nswrite_async_impl(struct future_context *ctx,
 		struct future_notifier *notifier)
 {
-	struct nswrite_async_future_data *data = future_context_get_data(ctx);
-	struct nswrite_async_future_output *output =
+	struct nswrite_async_data *data = future_context_get_data(ctx);
+	struct nswrite_async_output *output =
 			future_context_get_output(ctx);
 
 	struct pmemblk *pbp = (struct pmemblk *)data->ns;
@@ -417,7 +417,7 @@ nswrite_async(void *ns, unsigned lane, void *buf, size_t count, uint64_t off,
 		.output.return_value = 0,
 	};
 
-	FUTURE_INIT(&future, nswrite_async_future_impl);
+	FUTURE_INIT(&future, nswrite_async_impl);
 
 	return future;
 }
@@ -432,7 +432,7 @@ static enum future_state
 pmemblk_read_async_impl(struct future_context *ctx,
 	struct future_notifier *notifier)
 {
-	struct pmemblk_read_async_future_data *data =
+	struct pmemblk_read_async_data *data =
 		future_context_get_data(ctx);
 	struct pmemblk_read_async_future_output *output =
 		future_context_get_output(ctx);
@@ -490,7 +490,7 @@ pmemblk_read_async(PMEMblkpool *pbp, void *buf, long long blockno)
  */
 
 /*
- * START of the pmemblk_write_async_fut future
+ * START of the pmemblk_write_async_future future
  */
 static enum future_state
 pmemblk_write_async_impl(struct future_context *ctx,
@@ -499,10 +499,7 @@ pmemblk_write_async_impl(struct future_context *ctx,
 	struct pmemblk_write_async_data *data =
 		future_context_get_data(ctx);
 	struct pmemblk_write_async_output *output =
-	struct pmemblk_write_async_future_data *data =
-			future_context_get_data(ctx);
-	struct pmemblk_write_async_future_output *output =
-			future_context_get_output(ctx);
+		future_context_get_data(ctx);
 
 	PMEMblkpool *pbp = data->pbp;
 	void *buf = data->buf;
@@ -553,17 +550,17 @@ set_output:
 	return FUTURE_STATE_COMPLETE;
 }
 
-struct pmemblk_write_async_fut
+struct pmemblk_write_async_future
 pmemblk_write_async(PMEMblkpool *pbp, void *buf, long long blockno)
 {
-	struct pmemblk_write_async_fut future = {
+	struct pmemblk_write_async_future future = {
 		.data.pbp = pbp,
 		.data.buf = buf,
 		.data.blockno = blockno,
 		.data.internal.lane = -1,
 		.data.stage = PMEMBLK_WRITE_INITIALIZED,
 
-		.output.return_value = 0,
+		.output.return_value = -1,
 	};
 
 	FUTURE_INIT(&future, pmemblk_write_async_impl);
@@ -571,7 +568,7 @@ pmemblk_write_async(PMEMblkpool *pbp, void *buf, long long blockno)
 	return future;
 }
 /*
- * END of the pmemblk_write_async_fut future
+ * END of the pmemblk_write_async_future future
  */
 
 /* async callbacks for btt_init() */

--- a/src/libpmemblk/blk.c
+++ b/src/libpmemblk/blk.c
@@ -494,6 +494,9 @@ static enum future_state
 pmemblk_write_async_impl(struct future_context *ctx,
 		struct future_notifier *notifier)
 {
+	struct pmemblk_write_async_data *data =
+		future_context_get_data(ctx);
+	struct pmemblk_write_async_output *output =
 	struct pmemblk_write_async_future_data *data =
 			future_context_get_data(ctx);
 	struct pmemblk_write_async_future_output *output =

--- a/src/libpmemblk/blk.c
+++ b/src/libpmemblk/blk.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2014-2020, Intel Corporation */
+/* Copyright 2014-2022, Intel Corporation */
 
 /*
  * blk.c -- block memory pool entry points for libpmem

--- a/src/libpmemblk/blk.h
+++ b/src/libpmemblk/blk.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-/* Copyright 2014-2021, Intel Corporation */
+/* Copyright 2014-2022, Intel Corporation */
 
 /*
  * blk.h -- internal definitions for libpmem blk module

--- a/src/libpmemblk/btt.c
+++ b/src/libpmemblk/btt.c
@@ -2291,7 +2291,6 @@ btt_read_async_impl(struct future_context *ctx,
 		return FUTURE_STATE_RUNNING;
 	}
 
-
 	/* done with read, so clear out rtt entry */
 	data->internal.arenap->rtt[lane] = BTT_MAP_ENTRY_ERROR;
 

--- a/src/libpmemblk/btt.c
+++ b/src/libpmemblk/btt.c
@@ -2114,9 +2114,9 @@ static enum future_state
 btt_read_async_impl(struct future_context *ctx,
 		struct future_notifier *notifier)
 {
-	struct btt_read_async_future_data *data =
+	struct btt_read_async_data *data =
 		future_context_get_data(ctx);
-	struct btt_read_async_future_output *output =
+	struct btt_read_async_output *output =
 		future_context_get_output(ctx);
 
 	struct btt *bttp = data->bttp;
@@ -2332,9 +2332,9 @@ static enum future_state
 btt_write_async_impl(struct future_context *ctx,
 		struct future_notifier *notifier)
 {
-	struct btt_write_async_future_data *data =
+	struct btt_write_async_data *data =
 			future_context_get_data(ctx);
-	struct btt_write_async_future_output *output =
+	struct btt_write_async_output *output =
 			future_context_get_output(ctx);
 
 	struct btt *bttp = data->bttp;

--- a/src/test/blk_future/TESTS.py
+++ b/src/test/blk_future/TESTS.py
@@ -7,7 +7,6 @@
 import sys
 
 import testframework as t
-from testframework import granularity as g
 from consts import MINIASYNC_LIBDIR
 
 

--- a/src/test/tools/bttcreate/bttcreate.c
+++ b/src/test/tools/bttcreate/bttcreate.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2016-2020, Intel Corporation */
+/* Copyright 2016-2022, Intel Corporation */
 /*
  * bttcreate.c -- tool for generating BTT layout
  */


### PR DESCRIPTION
Mainly I added stages to pmemblk_write_async, added another exit point in the future - `WAITING_FOR_READ`. Fixed some of my bugs, changes names a little so they are shorter and changed error handling, so defaultly futures have `output->return_value = -1`, so we have to set 0 explicitly when the future is done.